### PR TITLE
Update to quik@0.4.7. Fixes #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react": "4.2.3",
     "http-server": "0.9.0",
     "npm-run-all": "1.5.1",
-    "quik": "0.4.6",
+    "quik": "0.4.7",
     "rimraf": "2.5.2",
     "surge": "0.17.7"
   },


### PR DESCRIPTION
Caveats: Sourcemaps become unusable in production actually. I'll be looking into how to fix this, but probably this is not supported (?)
